### PR TITLE
ci: add continuous integration testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on: ['push', 'pull_request']
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    name: HACS Action
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  hassfest:
+    runs-on: ubuntu-latest
+    name: Hassfest Validation
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Hassfest Validation
+        uses: home-assistant/actions/hassfest@master
+
+  style:
+    runs-on: ubuntu-latest
+    name: Check style formatting
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: python3 -m pip install black
+
+      - name: Style Check
+        run: black --color --check .

--- a/custom_components/ohdear/__init__.py
+++ b/custom_components/ohdear/__init__.py
@@ -20,7 +20,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         name=config_entry.title,
         api_token=config_entry.data[CONF_API_TOKEN],
         site_id=config_entry.data[CONF_SITE_ID],
-        update_interval=timedelta(minutes=(config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)))
+        update_interval=timedelta(
+            minutes=(config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        ),
     )
 
     await ohdear_coordinator.async_config_entry_first_refresh()

--- a/custom_components/ohdear/config_flow.py
+++ b/custom_components/ohdear/config_flow.py
@@ -11,11 +11,15 @@ import homeassistant.helpers.config_validation as cv
 
 from .const import DOMAIN, CONF_SITE_ID, DEFAULT_SCAN_INTERVAL
 
-CONFIG_SCHEMA = vol.Schema({
-    vol.Required(CONF_SITE_ID): cv.positive_int,
-    vol.Required(CONF_API_TOKEN): cv.string,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=1)),
-})
+CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_SITE_ID): cv.positive_int,
+        vol.Required(CONF_API_TOKEN): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
+    }
+)
 
 
 class OhDearConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -29,11 +33,14 @@ class OhDearConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             try:
                 site = await self.hass.async_add_executor_job(
-                    lambda: get_site(api_token=user_input[CONF_API_TOKEN], site_id=user_input[CONF_SITE_ID])
+                    lambda: get_site(
+                        api_token=user_input[CONF_API_TOKEN],
+                        site_id=user_input[CONF_SITE_ID],
+                    )
                 )
                 if site:
                     # Make sure we're not configuring the same device
-                    await self.async_set_unique_id(f'ohdear_{user_input[CONF_SITE_ID]}')
+                    await self.async_set_unique_id(f"ohdear_{user_input[CONF_SITE_ID]}")
                     self._abort_if_unique_id_configured()
 
                     return self.async_create_entry(
@@ -41,11 +48,11 @@ class OhDearConfigFlow(ConfigFlow, domain=DOMAIN):
                         data=user_input,
                     )
             except UnauthorizedException:
-                errors[CONF_API_TOKEN] = 'invalid_api_token'
+                errors[CONF_API_TOKEN] = "invalid_api_token"
             except NotFoundException:
-                errors[CONF_SITE_ID] = 'invalid_site_id'
+                errors[CONF_SITE_ID] = "invalid_site_id"
             else:
-                errors[CONF_API_TOKEN] = 'server_error'
+                errors[CONF_API_TOKEN] = "server_error"
 
         return self.async_show_form(
             step_id="user", data_schema=CONFIG_SCHEMA, errors=errors

--- a/custom_components/ohdear/const.py
+++ b/custom_components/ohdear/const.py
@@ -1,7 +1,7 @@
 """Constants for the Oh Dear integration."""
 from typing import Final
 
-DOMAIN: Final = 'ohdear'
+DOMAIN: Final = "ohdear"
 
-CONF_SITE_ID: Final = 'site_id'
+CONF_SITE_ID: Final = "site_id"
 DEFAULT_SCAN_INTERVAL: Final = 5

--- a/custom_components/ohdear/coordinator.py
+++ b/custom_components/ohdear/coordinator.py
@@ -12,8 +12,14 @@ _LOGGER = logging.getLogger(__name__)
 class OhDearUpdateCoordinator(DataUpdateCoordinator[Site]):
     """Coordinates updates between all Oh Dear sensors defined."""
 
-    def __init__(self, hass: HomeAssistant, name: str, api_token: str, site_id: int,
-                 update_interval: timedelta) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        name: str,
+        api_token: str,
+        site_id: int,
+        update_interval: timedelta,
+    ) -> None:
         self._ohdear = OhDear(api_token=api_token)
         self._site_id = site_id
 

--- a/custom_components/ohdear/entity.py
+++ b/custom_components/ohdear/entity.py
@@ -12,18 +12,22 @@ class OhDearSensorEntity(CoordinatorEntity[OhDearUpdateCoordinator], SensorEntit
 
     entity_description: SensorEntityDescription
 
-    def __init__(self, coordinator: OhDearUpdateCoordinator, description: SensorEntityDescription):
+    def __init__(
+        self, coordinator: OhDearUpdateCoordinator, description: SensorEntityDescription
+    ):
         """Initialize the sensor and set the update coordinator."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_name = f"{self.coordinator.data['label']} {self.entity_description.name}"
+        self._attr_name = (
+            f"{self.coordinator.data['label']} {self.entity_description.name}"
+        )
         self._attr_unique_id = f"{self.coordinator.data['id']}_{description.key}"
 
     @property
     def native_value(self) -> str:
-        for check in self.coordinator.data['checks']:
-            if check['type'] == self.entity_description.key and check['enabled']:
-                return check['latest_run_result']
+        for check in self.coordinator.data["checks"]:
+            if check["type"] == self.entity_description.key and check["enabled"]:
+                return check["latest_run_result"]
 
         return STATE_UNAVAILABLE
 
@@ -31,9 +35,9 @@ class OhDearSensorEntity(CoordinatorEntity[OhDearUpdateCoordinator], SensorEntit
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return DeviceInfo(
-            name=self.coordinator.data['label'],
+            name=self.coordinator.data["label"],
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, f'{self.coordinator.data["id"]}')},
-            manufacturer='Oh Dear',
-            configuration_url=f'https://ohdear.app/sites/{self.coordinator.data["id"]}/active-checks'
+            manufacturer="Oh Dear",
+            configuration_url=f'https://ohdear.app/sites/{self.coordinator.data["id"]}/active-checks',
         )

--- a/custom_components/ohdear/manifest.json
+++ b/custom_components/ohdear/manifest.json
@@ -3,6 +3,7 @@
   "name": "Oh Dear",
   "version": "0.1.5",
   "documentation": "https://github.com/owenvoke/hass-ohdear",
+  "issue_tracker": "https://github.com/owenvoke/hass-ohdear/issues",
   "requirements": ["ohdear-sdk==0.3.6"],
   "codeowners": ["@owenvoke"],
   "iot_class": "cloud_polling",

--- a/custom_components/ohdear/sensor.py
+++ b/custom_components/ohdear/sensor.py
@@ -10,13 +10,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import OhDearUpdateCoordinator
 from .entity import OhDearSensorEntity
 
-DOMAIN = 'ohdear'
+DOMAIN = "ohdear"
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
-ICON = 'mdi:list-status'
+ICON = "mdi:list-status"
 
 SCAN_INTERVAL = timedelta(minutes=5)
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "Oh Dear",
   "render_readme": true,
-  "homeassistant": "2022.11.1",
-  "iot_class": "cloud_polling"
+  "homeassistant": "2022.11.1"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This adds continuous integration testing to the integration. Only 1 test is currently failing at the moment (need to add Oh Dear to the [`brands` repository](https://github.com/home-assistant/brands).

PR opened at https://github.com/home-assistant/brands/pull/3850 to add the logos to the `brands` repository.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/main/CONTRIBUTING.md)** document.
